### PR TITLE
Load tags, country and bio for performer

### DIFF
--- a/Jellyfin.Plugin.Stash/Consts.cs
+++ b/Jellyfin.Plugin.Stash/Consts.cs
@@ -8,7 +8,7 @@ namespace Stash
 
         public const string PerformerSearchQuery = @"query{{findPerformers({0}){{performers{{id,name,disambiguation,image_path,birthdate}}}}}}";
 
-        public const string PerformerQuery = @"query{{findPerformer(id:{0}){{id,name,disambiguation,image_path,alias_list,birthdate,death_date}}}}";
+        public const string PerformerQuery = @"query{{findPerformer(id:{0}){{id,name,details,disambiguation,image_path,alias_list,birthdate,death_date,country,tags{{name}}}}}}";
 
         public const string StudiosSearchQuery = @"query{{findStudios({0}){{studios{{id,name,image_path}}}}}}";
 

--- a/Jellyfin.Plugin.Stash/Models/Performer.cs
+++ b/Jellyfin.Plugin.Stash/Models/Performer.cs
@@ -12,6 +12,9 @@ namespace Stash.Models
         [JsonProperty(PropertyName = "name")]
         public string Name { get; set; }
 
+        [JsonProperty(PropertyName = "details")]
+        public string Details { get; set; }
+
         [JsonProperty(PropertyName = "disambiguation")]
         public string Disambiguation { get; set; }
 
@@ -26,5 +29,11 @@ namespace Stash.Models
 
         [JsonProperty(PropertyName = "death_date")]
         public DateTime? DeathDate { get; set; }
+
+        [JsonProperty(PropertyName = "tags")]
+        public List<Tags> Tags { get; set; }
+
+        [JsonProperty(PropertyName = "country")]
+        public string Country { get; set; }
     }
 }

--- a/Jellyfin.Plugin.Stash/Providers/StashAPI.cs
+++ b/Jellyfin.Plugin.Stash/Providers/StashAPI.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Web;
@@ -156,11 +158,11 @@ namespace Stash.Providers
                 result.Item.AddStudio(studioName);
             }
 
-            foreach (var genreLink in sceneData.Tags)
+            foreach (var tag in sceneData.Tags)
             {
-                var genreName = genreLink.Name;
+                var tagName = tag.Name;
 
-                result.Item.AddGenre(genreName);
+                result.Item.AddTag(tagName);
             }
 
             foreach (var actorLink in sceneData.Performers)
@@ -289,9 +291,21 @@ namespace Stash.Providers
             var sceneData = JsonConvert.DeserializeObject<Performer>(data);
 
             result.Item.OriginalTitle = string.Join(", ", sceneData.AliasList);
-
+            result.Item.Overview = sceneData.Details;
             result.Item.PremiereDate = sceneData.BirthDate;
             result.Item.EndDate = sceneData.DeathDate;
+
+            if (sceneData.Country.Any())
+            {
+                result.Item.ProductionLocations = new string[] { new RegionInfo(sceneData.Country.Trim()).EnglishName };
+            }
+
+            foreach (var tag in sceneData.Tags)
+            {
+                var tagName = tag.Name;
+
+                result.Item.AddTag(tagName);
+            }
 
             result.HasMetadata = true;
 


### PR DESCRIPTION
Load more data for performer:

- tags
- country
- bio

Additionally fixed a bug where scene tags were saved into genre instead of tags.